### PR TITLE
fix: add explicit nullable type for PHP8.4

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -10,7 +10,7 @@ if ( ! function_exists('laravel_version')) {
      *
      * @return string|bool
      */
-    function laravel_version(string $version = null) {
+    function laravel_version(?string $version = null) {
         $appVersion = app()->version();
 
         if (is_null($version)) {


### PR DESCRIPTION
Hello!

This explicitly adds the nullable type to prevent deprecation warnings on PHP8.4. It seems like deprecations don't mix well with json endpoints so this is causing issues when trying to update PHP versions.

Thanks!